### PR TITLE
feat: add partner testimonials section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import HeroSlideshow from "@/components/home/HeroSlideshow";
 import ServicesIntro from "@/components/home/ServicesIntro";
+import PartnersTestimonials from "@/components/home/PartnersTestimonials";
 import LocationsPreview from "@/components/home/LocationsPreview";
 import BlogPreview from "@/components/home/BlogPreview";
 import LeafDivider from "@/components/shared/LeafDivider";
@@ -10,8 +11,9 @@ export default function HomePage() {
       <HeroSlideshow />
       <ServicesIntro />
       <LeafDivider />
+      <PartnersTestimonials />
       <LocationsPreview />
-      <LeafDivider />
+      <LeafDivider className="bg-green-50" />
       <BlogPreview />
     </>
   );

--- a/src/components/home/PartnersTestimonials.tsx
+++ b/src/components/home/PartnersTestimonials.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { Quote } from "lucide-react";
+import SectionHeading from "@/components/shared/SectionHeading";
+import LeafDivider from "@/components/shared/LeafDivider";
+import { useInView } from "@/lib/useInView";
+import { testimonials } from "@/data/testimonials";
+
+function getInitials(name: string): string {
+  const parts = name.trim().split(" ");
+  if (parts.length >= 2) {
+    return (parts[0][0] + parts[1][0]).toUpperCase();
+  }
+  return parts[0].slice(0, 2).toUpperCase();
+}
+
+export default function PartnersTestimonials() {
+  const ref = useInView<HTMLDivElement>();
+
+  return (
+    <section className="bg-green-900 py-20 md:py-28">
+      <div className="max-w-6xl mx-auto px-4 md:px-8 lg:px-16">
+        <SectionHeading
+          title="Što kažu naši partneri"
+          subtitle="Povjerenje koje gradimo godinama, svjedočanstvo onih koji to najbolje znaju."
+          light
+        />
+
+        <div
+          ref={ref}
+          className="stagger-children grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8"
+        >
+          {testimonials.map((t) => (
+            <div
+              key={t.id}
+              className="animate-on-scroll anim-fade-in-up flex flex-col gap-4 rounded-2xl border border-white/10 bg-white/5 p-6 md:p-8 backdrop-blur-sm"
+            >
+              {/* Quote icon */}
+              <Quote className="w-8 h-8 text-green-400 shrink-0" />
+
+              {/* Testimonial text */}
+              <p className="text-green-50 leading-relaxed text-sm md:text-base flex-1">
+                &ldquo;{t.quote}&rdquo;
+              </p>
+
+              {/* Partner info */}
+              <div className="flex items-center gap-3 border-t border-white/10 pt-4">
+                <div className="w-10 h-10 rounded-full bg-green-700 flex items-center justify-center shrink-0">
+                  <span className="text-white text-sm font-semibold">
+                    {getInitials(t.name)}
+                  </span>
+                </div>
+                <div className="min-w-0">
+                  <p className="text-white font-semibold text-sm truncate">
+                    {t.name}
+                  </p>
+                  <p className="text-green-300 text-xs truncate">
+                    {t.role} &middot; {t.company}
+                    {t.location && `, ${t.location}`}
+                  </p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <LeafDivider light />
+    </section>
+  );
+}

--- a/src/components/shared/LeafDivider.tsx
+++ b/src/components/shared/LeafDivider.tsx
@@ -1,15 +1,22 @@
-export default function LeafDivider() {
+import { cn } from "@/lib/utils";
+
+interface Props {
+  className?: string;
+  light?: boolean;
+}
+
+export default function LeafDivider({ className, light }: Props) {
   return (
-    <div className="flex items-center justify-center py-12 px-4">
-      <div className="h-px bg-green-200 flex-1 max-w-32" />
+    <div className={cn("flex items-center justify-center py-8 px-4", className)}>
+      <div className={cn("h-px flex-1 max-w-32", light ? "bg-white/60" : "bg-green-200")} />
       <svg
         viewBox="0 0 40 40"
-        className="w-10 h-10 mx-4 text-green-500"
+        className={cn("w-10 h-10 mx-4", light ? "text-white/90" : "text-green-500")}
         fill="currentColor"
       >
         <path d="M20 2C14 8 4 14 4 24c0 6 4 10 8 12 1-4 3-8 8-12-5 6-7 10-7 14 2 1 4 1 7 0 3-1 5-2 7-4C31 30 34 24 34 18c0-6-4-10-14-16z" />
       </svg>
-      <div className="h-px bg-green-200 flex-1 max-w-32" />
+      <div className={cn("h-px flex-1 max-w-32", light ? "bg-white/60" : "bg-green-200")} />
     </div>
   );
 }

--- a/src/data/testimonials.ts
+++ b/src/data/testimonials.ts
@@ -1,0 +1,65 @@
+export interface Testimonial {
+  id: number;
+  quote: string;
+  name: string;
+  role: string;
+  company: string;
+  location?: string;
+}
+
+export const testimonials: Testimonial[] = [
+  {
+    id: 1,
+    quote:
+      "S Oroz PHARM-om surađujemo već više od deset godina. Uvijek su tu s pravim savjetom, kvalitetnim sjemenom i gnojivima na vrijeme. Bez njih naša bi OPG priča bila puno teža.",
+    name: "Ivan Pavlović",
+    role: "Vlasnik",
+    company: "OPG Pavlović",
+    location: "Pleternica",
+  },
+  {
+    id: 2,
+    quote:
+      "Odlična ponuda sredstava za zaštitu vinograda i stručan pristup svakom upitu. Ekipa iz Požege uvijek preporuči pravo rješenje za naše potrebe, bez nepotrebne prodaje.",
+    name: "Marija Horvat",
+    role: "Vinogradarka",
+    company: "Vinarija Horvat",
+    location: "Kutjevo",
+  },
+  {
+    id: 3,
+    quote:
+      "Nabavljamo pčelarsku opremu i prehranu za pčele isključivo kod njih. Asortiman je uvijek kompletan, a cijene su poštene. Preporučujem svim pčelarima u regiji.",
+    name: "Stjepan Blažević",
+    role: "Pčelar",
+    company: "OPG Blažević",
+    location: "Brestovac",
+  },
+  {
+    id: 4,
+    quote:
+      "Koristimo njihova gnojiva i stočnu hranu već godinama. Kvaliteta je konstantna, a dostava uvijek točna. Pouzdani partner za svako gospodarstvo.",
+    name: "Zdravko Marić",
+    role: "Stočar",
+    company: "Farma Marić",
+    location: "Jakšić",
+  },
+  {
+    id: 5,
+    quote:
+      "Kao mladi OPG, Oroz PHARM nam je pomogao savjetom pri prvom postavljanju navodnjavanja. Stručnost i strpljivost osoblja zaista se cijeni kad tek počinješ.",
+    name: "Petra Jurić",
+    role: "Voćarka",
+    company: "OPG Jurić",
+    location: "Vetovo",
+  },
+  {
+    id: 6,
+    quote:
+      "Redovito nabavljamo sadnice, supstrat i opremu za povrtarstvo. Sve je na jednom mjestu, a savjeti su uvijek besplatni i stručni. Pravi partner u poslu.",
+    name: "Ante Kovač",
+    role: "Povrtlar",
+    company: "OPG Kovač",
+    location: "Požega",
+  },
+];


### PR DESCRIPTION
## Summary
- Adds new **Što kažu naši partneri** section to the home page with 6 placeholder partner testimonials
- Responsive grid: 1 → 2 → 3 columns with scroll-triggered stagger animations
- Updates `LeafDivider` with `light` and `className` props for use on dark backgrounds (white lines/icon variant)

## Files changed
- `src/data/testimonials.ts` — `Testimonial` interface + 6 Croatian partner quotes
- `src/components/home/PartnersTestimonials.tsx` — new section component
- `src/components/shared/LeafDivider.tsx` — added `light` and `className` props
- `src/app/page.tsx` — integrated new section into home page

## Test plan
- [ ] `npm run dev` → verify section renders on home page
- [ ] Check responsive layout at sm / md / lg breakpoints
- [ ] Verify stagger scroll animations trigger on scroll
- [ ] Confirm `LeafDivider light` variant shows white lines/icon on green-900 background
- [ ] `npm run build` → no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)