### PR TITLE
feat: add related categories with manual curation and subcategory sup…

### DIFF
--- a/src/collections/Categories.ts
+++ b/src/collections/Categories.ts
@@ -53,5 +53,15 @@ export const Categories: CollectionConfig = {
         description: 'CSS grid-area naziv za pozicioniranje u rešetki',
       },
     },
+    {
+      name: 'relatedCategories',
+      type: 'relationship',
+      relationTo: 'categories',
+      hasMany: true,
+      label: 'Srodne kategorije',
+      admin: {
+        description: 'Kategorije prikazane u dijelu "Možda vas zanima" na stranici kategorije (max 3)',
+      },
+    },
   ],
 }

--- a/src/components/products/CategoryDetailClient.tsx
+++ b/src/components/products/CategoryDetailClient.tsx
@@ -79,7 +79,7 @@ export default function CategoryDetailClient({ category, products }: Props) {
         <div className="flex flex-wrap gap-2 mb-8 pb-8 border-b border-green-100">
           <button
             onClick={() => setActiveMfr("svi")}
-            className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-colors ${
+            className={`px-3 py-1.5 rounded-full text-sm font-semibold transition-colors ${
               activeMfr === "svi"
                 ? "bg-earth-500 text-white"
                 : "bg-earth-100 text-earth-700 hover:bg-earth-200"
@@ -91,7 +91,7 @@ export default function CategoryDetailClient({ category, products }: Props) {
             <button
               key={mfr}
               onClick={() => setActiveMfr(mfr)}
-              className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-colors ${
+              className={`px-3 py-1.5 rounded-full text-sm font-semibold transition-colors ${
                 activeMfr === mfr
                   ? "bg-earth-500 text-white"
                   : "bg-earth-100 text-earth-700 hover:bg-earth-200"

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -127,6 +127,7 @@ export interface Category {
   icon?: string | null;
   image?: number | Media | null;
   gridArea?: string | null;
+  relatedCategories?: (number | Category)[] | null;
   updatedAt: string;
   createdAt: string;
 }


### PR DESCRIPTION
…port

- Add `relatedCategories` relationship field to Categories collection
- Category detail page uses curated related categories if set in CMS, otherwise falls back to auto-selected (3 other categories)
- Fetch all subcategories in a single query and group by parent ID via Map, so both the active category and related category cards display subcategories
- Products list page also fetches subcategories in parallel and passes them to each category card
- Bump manufacturer filter button size from text-xs to text-sm