### PR TITLE
feat: add contact form with Resend email integration and Payload subm…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-dom": "19.2.3",
         "react-hook-form": "^7.71.1",
         "react-leaflet": "^5.0.0",
+        "resend": "^6.9.2",
         "sharp": "^0.34.5",
         "zod": "^4.3.6"
       },
@@ -2969,6 +2970,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz",
       "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
@@ -6101,6 +6108,12 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -8884,6 +8897,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.4.11.tgz",
       "integrity": "sha512-IJRyXal45mIsshZI5XJne/intjusslUP1F+FHVBIyMGEqbYtIq1Irdx5vdWBBg58smviPDycmDeV6txsfkv1RQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.4.11",
         "@swc/helpers": "0.5.15",
@@ -9667,6 +9681,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.3.tgz",
+      "integrity": "sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -9933,7 +9953,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10239,6 +10258,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resend": {
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.9.2.tgz",
+      "integrity": "sha512-uIM6CQ08tS+hTCRuKBFbOBvHIGaEhqZe8s4FOgqsVXSbQLAhmNWpmUhG3UAtRnmcwTWFUqnHa/+Vux8YGPyDBA==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.3",
+        "svix": "1.84.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -10390,7 +10430,6 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.4.tgz",
       "integrity": "sha512-vcF3Ckow6g939GMA4PeU7b2K/9FALXk2KF9J87txdHzXbUF9XRQRwSxcAs/fGaTnJeBFd7UoV22j3lzMLdM0Pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -10753,6 +10792,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/state-local": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
@@ -11027,6 +11076,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.84.1",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.84.1.tgz",
+      "integrity": "sha512-K8DPPSZaW/XqXiz1kEyzSHYgmGLnhB43nQCMeKjWGCUpLIpAMMM8kx3rVVOSm6Bo6EHyK1RQLPT4R06skM/MlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/tabbable": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint",
     "seed": "node --env-file=.env.local src/scripts/seed.js",
     "seed:images": "node --env-file=.env.local src/scripts/seed-images.js",
-    "seed:subcategories": "node --env-file=.env.local src/scripts/seed-subcategories.js"
+    "seed:subcategories": "node --env-file=.env.local src/scripts/seed-subcategories.js",
+    "seed:related": "node --env-file=.env.local src/scripts/seed-related-categories.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -27,6 +28,7 @@
     "react-dom": "19.2.3",
     "react-hook-form": "^7.71.1",
     "react-leaflet": "^5.0.0",
+    "resend": "^6.9.2",
     "sharp": "^0.34.5",
     "zod": "^4.3.6"
   },

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -30,6 +30,7 @@ import { Manufacturers } from '@/collections/Manufacturers'
 import { Subcategories } from '@/collections/Subcategories'
 import { Categories } from '@/collections/Categories'
 import { Products } from '@/collections/Products'
+import { ContactSubmissions } from '@/collections/ContactSubmissions'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -65,6 +66,7 @@ export default buildConfig({
     Subcategories,
     Categories,
     Products,
+    ContactSubmissions,
   ],
   editor: lexicalEditor({
     features: () => [

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,0 +1,175 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { Resend } from "resend";
+import { getPayload } from "payload";
+import config from "@payload-config";
+
+const schema = z.object({
+  name: z.string().min(2),
+  email: z.string().email(),
+  phone: z.string().optional(),
+  category: z.string().min(1),
+  message: z.string().min(10),
+});
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+const FROM_EMAIL = "noreply@orozpharm.hr";
+const TO_EMAIL = process.env.CONTACT_TO_EMAIL ?? "perica@orozpharm.hr";
+
+export async function POST(req: NextRequest) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Neispravan zahtjev." }, { status: 400 });
+  }
+
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validacijska greška." },
+      { status: 422 },
+    );
+  }
+
+  const { name, email, phone, category, message } = parsed.data;
+
+  // 1. Pohrana u Payload
+  try {
+    const payload = await getPayload({ config });
+    await payload.create({
+      collection: "contact-submissions",
+      data: {
+        name,
+        email,
+        phone: phone ?? null,
+        category,
+        message,
+        status: "novo",
+      },
+    });
+  } catch (err) {
+    console.error("[contact] Payload create error:", err);
+    return NextResponse.json(
+      { error: "Greška pri pohrani upita." },
+      { status: 500 },
+    );
+  }
+
+  // 2. Admin notifikacija
+  try {
+    await resend.emails.send({
+      from: FROM_EMAIL,
+      to: TO_EMAIL,
+      subject: `Novi upit — ${category} — ${name}`,
+      html: adminEmailHtml({ name, email, phone, category, message }),
+    });
+  } catch (err) {
+    console.error("[contact] Resend admin email error:", err);
+    // Ne blokiramo odgovor ako admin mail ne prođe
+  }
+
+  // 3. Auto-reply potvrdni mail
+  try {
+    await resend.emails.send({
+      from: FROM_EMAIL,
+      to: email,
+      subject: "Vaš upit je primljen — Oroz PHARM",
+      html: autoReplyHtml({ name, category, message }),
+    });
+  } catch (err) {
+    console.error("[contact] Resend auto-reply error:", err);
+    // Ne blokiramo odgovor ako auto-reply ne prođe
+  }
+
+  return NextResponse.json({ success: true });
+}
+
+function adminEmailHtml(data: {
+  name: string;
+  email: string;
+  phone?: string;
+  category: string;
+  message: string;
+}) {
+  return `
+<!DOCTYPE html>
+<html lang="hr">
+<head><meta charset="utf-8" /></head>
+<body style="font-family: sans-serif; color: #1a1a1a; max-width: 600px; margin: 0 auto; padding: 24px;">
+  <h2 style="color: #166534; margin-bottom: 4px;">Novi upit s web stranice</h2>
+  <p style="color: #6b7280; margin-top: 0; margin-bottom: 24px;">Primljeno putem kontaktne forme na orozpharm.hr</p>
+
+  <table style="width: 100%; border-collapse: collapse;">
+    <tr>
+      <td style="padding: 10px 0; border-bottom: 1px solid #e5e7eb; width: 140px; color: #6b7280; font-size: 13px; text-transform: uppercase; letter-spacing: 0.05em;">Ime i prezime</td>
+      <td style="padding: 10px 0; border-bottom: 1px solid #e5e7eb; font-weight: 600;">${escHtml(data.name)}</td>
+    </tr>
+    <tr>
+      <td style="padding: 10px 0; border-bottom: 1px solid #e5e7eb; color: #6b7280; font-size: 13px; text-transform: uppercase; letter-spacing: 0.05em;">Email</td>
+      <td style="padding: 10px 0; border-bottom: 1px solid #e5e7eb;"><a href="mailto:${escHtml(data.email)}" style="color: #166534;">${escHtml(data.email)}</a></td>
+    </tr>
+    ${
+      data.phone
+        ? `
+    <tr>
+      <td style="padding: 10px 0; border-bottom: 1px solid #e5e7eb; color: #6b7280; font-size: 13px; text-transform: uppercase; letter-spacing: 0.05em;">Telefon</td>
+      <td style="padding: 10px 0; border-bottom: 1px solid #e5e7eb;">${escHtml(data.phone)}</td>
+    </tr>`
+        : ""
+    }
+    <tr>
+      <td style="padding: 10px 0; border-bottom: 1px solid #e5e7eb; color: #6b7280; font-size: 13px; text-transform: uppercase; letter-spacing: 0.05em;">Kategorija</td>
+      <td style="padding: 10px 0; border-bottom: 1px solid #e5e7eb;">${escHtml(data.category)}</td>
+    </tr>
+    <tr>
+      <td style="padding: 10px 0; vertical-align: top; color: #6b7280; font-size: 13px; text-transform: uppercase; letter-spacing: 0.05em;">Poruka</td>
+      <td style="padding: 10px 0; white-space: pre-line;">${escHtml(data.message)}</td>
+    </tr>
+  </table>
+</body>
+</html>
+  `.trim();
+}
+
+function autoReplyHtml(data: {
+  name: string;
+  category: string;
+  message: string;
+}) {
+  return `
+<!DOCTYPE html>
+<html lang="hr">
+<head><meta charset="utf-8" /></head>
+<body style="font-family: sans-serif; color: #1a1a1a; max-width: 600px; margin: 0 auto; padding: 24px;">
+  <h2 style="color: #166534; margin-bottom: 4px;">Hvala, ${escHtml(data.name)}!</h2>
+  <p style="color: #374151; margin-top: 0; margin-bottom: 16px;">
+    Vaša poruka je primljena. Javit ćemo vam se u najkraćem roku, najčešće unutar jednog radnog dana.
+  </p>
+
+  <div style="background: #f0fdf4; border-left: 4px solid #16a34a; padding: 16px 20px; border-radius: 4px; margin-bottom: 24px;">
+    <p style="margin: 0 0 8px; font-size: 13px; color: #6b7280; text-transform: uppercase; letter-spacing: 0.05em;">Vaš upit</p>
+    <p style="margin: 0 0 4px;"><strong>Kategorija:</strong> ${escHtml(data.category)}</p>
+    <p style="margin: 0; white-space: pre-line;">${escHtml(data.message)}</p>
+  </div>
+
+  <p style="color: #6b7280; font-size: 14px; margin-bottom: 4px;">
+    Oroz PHARM — Pleternica i Požega<br />
+    Radno vrijeme: pon–pet 07:00–17:00, sub 07:00–13:00
+  </p>
+  <p style="color: #9ca3af; font-size: 12px; margin-top: 24px;">
+    Ovu poruku primili ste jer ste ispunili kontaktnu formu na stranici orozpharm.hr.
+  </p>
+</body>
+</html>
+  `.trim();
+}
+
+function escHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/src/collections/ContactSubmissions.ts
+++ b/src/collections/ContactSubmissions.ts
@@ -1,0 +1,65 @@
+import type { CollectionConfig } from 'payload'
+
+const isAdmin = ({ req: { user } }: { req: { user: unknown } }) => {
+  return Boolean(user)
+}
+
+export const ContactSubmissions: CollectionConfig = {
+  slug: 'contact-submissions',
+  admin: {
+    useAsTitle: 'name',
+    defaultColumns: ['name', 'email', 'category', 'status', 'createdAt'],
+  },
+  access: {
+    read: isAdmin,
+    create: () => true,
+    update: isAdmin,
+    delete: isAdmin,
+  },
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+      label: 'Ime i prezime',
+    },
+    {
+      name: 'email',
+      type: 'email',
+      required: true,
+      label: 'Email adresa',
+    },
+    {
+      name: 'phone',
+      type: 'text',
+      label: 'Telefon',
+    },
+    {
+      name: 'category',
+      type: 'text',
+      required: true,
+      label: 'Kategorija upita',
+    },
+    {
+      name: 'message',
+      type: 'textarea',
+      required: true,
+      label: 'Poruka',
+    },
+    {
+      name: 'status',
+      type: 'select',
+      required: true,
+      defaultValue: 'novo',
+      label: 'Status',
+      options: [
+        { label: 'Novo', value: 'novo' },
+        { label: 'Odgovoreno', value: 'odgovoreno' },
+        { label: 'Arhivirano', value: 'arhivirano' },
+      ],
+      admin: {
+        position: 'sidebar',
+      },
+    },
+  ],
+}

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -44,6 +44,7 @@ const categories = [
 
 export default function ContactForm() {
   const [submitted, setSubmitted] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const ref = useInView<HTMLDivElement>();
   const {
     register,
@@ -53,10 +54,22 @@ export default function ContactForm() {
     resolver: zodResolver(schema),
   });
 
-  const onSubmit = async (_data: FormData) => {
-    // Simulate submission delay
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    setSubmitted(true);
+  const onSubmit = async (data: FormData) => {
+    setSubmitError(null);
+    try {
+      const res = await fetch("/api/contact", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        setSubmitError("Greška pri slanju poruke. Molimo pokušajte ponovo ili nas kontaktirajte telefonom.");
+        return;
+      }
+      setSubmitted(true);
+    } catch {
+      setSubmitError("Greška pri slanju poruke. Molimo pokušajte ponovo ili nas kontaktirajte telefonom.");
+    }
   };
 
   return (
@@ -101,7 +114,7 @@ export default function ContactForm() {
                 <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
+                      <label className="block text-base font-medium text-gray-700 mb-1">
                         Ime i prezime *
                       </label>
                       <input
@@ -114,7 +127,7 @@ export default function ContactForm() {
                       )}
                     </div>
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
+                      <label className="block text-base font-medium text-gray-700 mb-1">
                         Email *
                       </label>
                       <input
@@ -131,7 +144,7 @@ export default function ContactForm() {
 
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
+                      <label className="block text-base font-medium text-gray-700 mb-1">
                         Telefon
                       </label>
                       <input
@@ -142,7 +155,7 @@ export default function ContactForm() {
                       />
                     </div>
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
+                      <label className="block text-base font-medium text-gray-700 mb-1">
                         Kategorija *
                       </label>
                       <select
@@ -166,7 +179,7 @@ export default function ContactForm() {
                   </div>
 
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                    <label className="block text-base font-medium text-gray-700 mb-1">
                       Poruka *
                     </label>
                     <textarea
@@ -180,7 +193,7 @@ export default function ContactForm() {
                     )}
                   </div>
 
-                  <Button type="submit" size="lg" className="w-full gap-2">
+                  <Button type="submit" size="lg" className="w-full gap-2" disabled={isSubmitting}>
                     {isSubmitting ? (
                       "Slanje..."
                     ) : (
@@ -189,6 +202,10 @@ export default function ContactForm() {
                       </>
                     )}
                   </Button>
+
+                  {submitError && (
+                    <p className="text-red-600 text-sm text-center mt-2">{submitError}</p>
+                  )}
                 </form>
               </>
             )}

--- a/src/components/shared/Button.tsx
+++ b/src/components/shared/Button.tsx
@@ -9,6 +9,7 @@ interface Props {
   size?: "sm" | "md" | "lg";
   className?: string;
   type?: "button" | "submit";
+  disabled?: boolean;
 }
 
 export default function Button({
@@ -19,6 +20,7 @@ export default function Button({
   size = "md",
   className,
   type = "button",
+  disabled,
 }: Props) {
   const base = "inline-flex items-center justify-center font-semibold rounded-xl transition-[background-color,color,box-shadow] duration-300 cursor-pointer";
   const variants = {
@@ -39,7 +41,7 @@ export default function Button({
   }
 
   return (
-    <button type={type} onClick={onClick} className={classes}>
+    <button type={type} onClick={onClick} disabled={disabled} className={classes}>
       {children}
     </button>
   );

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -174,6 +174,20 @@ export interface Product {
   createdAt: string;
 }
 
+// ─── ContactSubmission ────────────────────────────────────────────────────────
+
+export interface ContactSubmission {
+  id: number;
+  name: string;
+  email: string;
+  phone?: string | null;
+  category: string;
+  message: string;
+  status: 'novo' | 'odgovoreno' | 'arhivirano';
+  updatedAt: string;
+  createdAt: string;
+}
+
 // ─── User ─────────────────────────────────────────────────────────────────────
 
 export interface User {
@@ -215,6 +229,7 @@ export interface Config {
     subcategories: Subcategory;
     categories: Category;
     products: Product;
+    'contact-submissions': ContactSubmission;
   };
   collectionsJoins: Record<string, never>;
   db: {


### PR DESCRIPTION
…issions

- Add ContactSubmissions Payload collection (name, email, phone, category, message, status) with public create access and admin-only read/update/delete
- Add /api/contact POST route: validates with Zod, saves to Payload, sends admin notification and auto-reply confirmation email via Resend
- Wire up ContactForm to real API call; replace setTimeout simulation with fetch; add error state displayed below submit button
- Add disabled prop to Button component
- Install resend package
- Add RESEND_API_KEY and CONTACT_TO_EMAIL env vars (documented in .env.local)