### PR TITLE
feat: slider sličnih proizvoda na stranici detalja proizvoda

### DIFF
--- a/src/app/(site)/proizvodi/[category]/[product]/page.tsx
+++ b/src/app/(site)/proizvodi/[category]/[product]/page.tsx
@@ -4,10 +4,12 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { getPayload } from "payload";
 import config from "@payload-config";
-import { ArrowLeft } from "lucide-react";
+import { ChevronRight, BookOpen } from "lucide-react";
 import { RichText } from "@payloadcms/richtext-lexical/react";
 import type { SerializedEditorState } from "lexical";
 import { getImageUrl } from "@/lib/utils";
+import type { Product } from "@/types/views";
+import RelatedProductsSlider from "@/components/products/RelatedProductsSlider";
 
 const FALLBACK_IMAGE =
   "https://images.unsplash.com/photo-1500382017468-9049fed747ef?w=800&q=80";
@@ -40,74 +42,161 @@ export default async function ProductPage({ params }: Props) {
   const { category: categorySlug, product: productSlug } = await params;
   const payload = await getPayload({ config });
 
-  const { docs } = await payload.find({
-    collection: "products",
-    where: { slug: { equals: productSlug } },
-    depth: 1,
-    limit: 1,
-  });
+  const [{ docs }, { docs: relatedDocs }] = await Promise.all([
+    payload.find({
+      collection: "products",
+      where: { slug: { equals: productSlug } },
+      depth: 1,
+      limit: 1,
+    }),
+    payload.find({
+      collection: "products",
+      where: {
+        and: [
+          { "category.slug": { equals: categorySlug } },
+          { slug: { not_equals: productSlug } },
+        ],
+      },
+      depth: 1,
+      limit: 11,
+      sort: "name",
+    }),
+  ]);
 
   const doc = docs[0];
   if (!doc) notFound();
 
   const image = getImageUrl(doc.image, FALLBACK_IMAGE);
+  const categoryName =
+    typeof doc.category === "object" && doc.category !== null
+      ? doc.category.name
+      : categorySlug;
   const manufacturerName =
     typeof doc.manufacturer === "object" && doc.manufacturer !== null
       ? doc.manufacturer.name
       : null;
 
+  const relatedProducts: Product[] = relatedDocs.map((p) => ({
+    id: String(p.id),
+    slug: p.slug,
+    categorySlug,
+    subcategoryId:
+      typeof p.subcategory === "object" && p.subcategory !== null
+        ? String(p.subcategory.id)
+        : String(p.subcategory ?? ""),
+    name: p.name,
+    manufacturer:
+      typeof p.manufacturer === "object" && p.manufacturer !== null
+        ? p.manufacturer.name
+        : "",
+    description: p.description ?? "",
+    instructions: p.instructions,
+    image: getImageUrl(p.image, FALLBACK_IMAGE),
+  }));
+
   return (
     <>
-      {/* Hero */}
-      <div className="relative h-[40vh] min-h-80 overflow-hidden">
-        <Image
-          src={image}
-          alt={doc.name}
-          fill
-          sizes="100vw"
-          className="object-cover"
-          priority
-        />
-        <div className="absolute inset-0 bg-linear-to-t from-green-900/85 via-green-900/40 to-transparent" />
-        <div className="absolute inset-0 flex items-end pb-12">
-          <div className="max-w-4xl mx-auto px-4 md:px-8 w-full">
+      {/* Breadcrumb */}
+      <nav className="max-w-6xl mx-auto px-4 md:px-8 pt-28 pb-2">
+        <ol className="flex items-center gap-1 text-sm flex-wrap">
+          <li>
+            <Link
+              href="/proizvodi"
+              className="text-green-600 hover:text-green-800 transition-colors"
+            >
+              Proizvodi
+            </Link>
+          </li>
+          <li className="flex items-center text-gray-400">
+            <ChevronRight size={14} />
+          </li>
+          <li>
             <Link
               href={`/proizvodi/${categorySlug}`}
-              className="inline-flex items-center gap-1 text-green-300 text-sm mb-4 hover:text-white transition-colors"
+              className="text-green-600 hover:text-green-800 transition-colors"
             >
-              <ArrowLeft size={16} /> Natrag na kategoriju
+              {categoryName}
             </Link>
+          </li>
+          <li className="hidden sm:flex items-center text-gray-400">
+            <ChevronRight size={14} />
+          </li>
+          <li className="hidden sm:block text-gray-500 truncate max-w-xs">
+            {doc.name}
+          </li>
+        </ol>
+      </nav>
+
+      {/* Product detail: image + info */}
+      <section className="max-w-6xl mx-auto px-4 md:px-8 pt-4 pb-10 md:pt-6 md:pb-14">
+        <div className="grid md:grid-cols-2 gap-10 md:gap-14 items-start">
+          {/* Image */}
+          <div className="md:sticky md:top-28">
+            <div className="relative aspect-square rounded-2xl overflow-hidden bg-gray-50 border border-green-100 shadow-sm">
+              <Image
+                src={image}
+                alt=""
+                fill
+                aria-hidden="true"
+                className="object-cover scale-110 blur-md opacity-40"
+              />
+              <Image
+                src={image}
+                alt={doc.name}
+                fill
+                sizes="(max-width: 768px) 100vw, 50vw"
+                className="object-contain"
+                priority
+              />
+            </div>
+          </div>
+
+          {/* Info */}
+          <div className="flex flex-col gap-4">
             {manufacturerName && (
-              <p className="text-green-300 text-sm font-semibold uppercase tracking-wide mb-2">
+              <span className="text-sm text-green-600 uppercase tracking-wide">
                 {manufacturerName}
-              </p>
+              </span>
             )}
-            <h1 className="text-3xl md:text-5xl font-bold text-white font-heading">
+            <h1 className="text-3xl md:text-4xl font-bold text-green-900 font-heading leading-tight">
               {doc.name}
             </h1>
+            {doc.description && (
+              <p className="text-gray-600 text-lg leading-relaxed">
+                {doc.description}
+              </p>
+            )}
+            {doc.instructions && (
+              <div className="bg-green-900 rounded-2xl px-6 py-5 mt-2">
+                <div className="flex items-center gap-2.5 mb-4">
+                  <div className="bg-green-600 rounded-lg p-1.5 shrink-0">
+                    <BookOpen size={16} className="text-white" />
+                  </div>
+                  <h2 className="text-base font-semibold text-white font-heading">
+                    Upute za primjenu
+                  </h2>
+                </div>
+                <div className="prose-blog text-sm [&_h2]:text-white [&_h2]:text-lg [&_h3]:text-green-200 [&_h3]:text-base [&_p]:text-white/85 [&_p]:mb-3 [&_li]:text-white/85 [&_ul]:mb-3 [&_blockquote]:text-white/70 [&_blockquote]:border-green-400">
+                  <RichText data={doc.instructions as SerializedEditorState} />
+                </div>
+              </div>
+            )}
           </div>
         </div>
-      </div>
+      </section>
 
-      {/* Content */}
-      <article className="max-w-4xl mx-auto px-4 md:px-8 py-12 md:py-16">
-        {doc.description && (
-          <p className="text-lg text-gray-600 leading-relaxed mb-10 pb-10 border-b border-green-100">
-            {doc.description}
-          </p>
-        )}
-
-        {doc.instructions && (
-          <>
-            <h2 className="text-2xl font-bold text-green-900 mb-6 font-heading">
-              Upute za primjenu
-            </h2>
-            <div className="prose-blog">
-              <RichText data={doc.instructions as SerializedEditorState} />
-            </div>
-          </>
-        )}
-      </article>
+      {/* Related products */}
+      {relatedProducts.length > 0 && (
+        <section className="border-t border-green-100">
+          <div className="max-w-6xl mx-auto px-4 md:px-8 py-12 md:py-16">
+            <RelatedProductsSlider
+              products={relatedProducts}
+              categorySlug={categorySlug}
+              categoryName={categoryName}
+            />
+          </div>
+        </section>
+      )}
     </>
   );
 }

--- a/src/components/products/ProductCard.tsx
+++ b/src/components/products/ProductCard.tsx
@@ -13,7 +13,7 @@ export default function ProductCard({ product }: Props) {
   return (
     <Link
       href={`/proizvodi/${product.categorySlug}/${product.slug}`}
-      className="group flex flex-col bg-white rounded-xl border border-green-100 overflow-hidden hover:shadow-lg hover:border-green-200 transition-all duration-300"
+      className="group flex flex-col h-full bg-white rounded-xl border border-green-100 overflow-hidden hover:shadow-lg hover:border-green-200 transition-all duration-300"
     >
       <div className="relative aspect-4/3 overflow-hidden bg-gray-100">
         <Image

--- a/src/components/products/RelatedProductsSlider.tsx
+++ b/src/components/products/RelatedProductsSlider.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useRef } from "react";
+import Link from "next/link";
+import { ChevronLeft, ChevronRight, ArrowRight } from "lucide-react";
+import ProductCard from "./ProductCard";
+import type { Product } from "@/types/views";
+
+interface Props {
+  products: Product[];
+  categorySlug: string;
+  categoryName: string;
+}
+
+export default function RelatedProductsSlider({
+  products,
+  categorySlug,
+  categoryName,
+}: Props) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const scroll = (direction: "left" | "right") => {
+    scrollRef.current?.scrollBy({
+      left: direction === "left" ? -1120 : 1120,
+      behavior: "smooth",
+    });
+  };
+
+  return (
+    <div>
+      {/* Header row with arrow controls */}
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-2xl font-bold text-green-900 font-heading">
+          Slični proizvodi
+        </h2>
+        <div className="flex gap-2">
+          <button
+            onClick={() => scroll("left")}
+            className="w-9 h-9 flex items-center justify-center rounded-full border border-green-200 hover:border-green-400 hover:bg-green-50 transition-all"
+            aria-label="Pomakni lijevo"
+          >
+            <ChevronLeft size={18} className="text-green-700" />
+          </button>
+          <button
+            onClick={() => scroll("right")}
+            className="w-9 h-9 flex items-center justify-center rounded-full border border-green-200 hover:border-green-400 hover:bg-green-50 transition-all"
+            aria-label="Pomakni desno"
+          >
+            <ChevronRight size={18} className="text-green-700" />
+          </button>
+        </div>
+      </div>
+
+      {/* Scrollable cards */}
+      <div
+        ref={scrollRef}
+        className="flex gap-5 overflow-x-auto snap-x snap-mandatory pb-2 [&::-webkit-scrollbar]:h-0"
+        style={{ scrollbarWidth: "none" }}
+      >
+        {products.map((p) => (
+          <div key={p.id} className="snap-start shrink-0 w-65">
+            <ProductCard product={p} />
+          </div>
+        ))}
+
+        {/* CTA — link to category */}
+        <div className="snap-start shrink-0 w-40 self-center">
+          <Link
+            href={`/proizvodi/${categorySlug}`}
+            className="flex flex-col items-center gap-3 p-4 text-center group"
+          >
+            <div className="w-12 h-12 rounded-full bg-green-100 flex items-center justify-center group-hover:bg-green-200 transition-colors">
+              <ArrowRight size={20} className="text-green-700" />
+            </div>
+            <span className="text-green-800 font-semibold text-sm leading-snug">
+              Svi proizvodi —<br />
+              {categoryName}
+            </span>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Novi RelatedProductsSlider klijentski komponent s ←/→ kontrolama
- Scroll po 4 kartice odjednom (snap-x snap-mandatory)
- CTA link (strelica + naziv kategorije) na kraju slidera
- Limit sličnih proizvoda povećan na 11 (stranice: 4, 4, 3 + CTA)
- ProductCard dobio h-full za jednaku visinu svih kartica
- Omjer slike na detaljima proizvoda povećan na 50/50 (bilo 2:3)