### PR TITLE
fix: dodaj canonical URL-ove, ispravi robots.txt i sitemap za SEO

### DIFF
--- a/src/app/(site)/blog/[slug]/page.tsx
+++ b/src/app/(site)/blog/[slug]/page.tsx
@@ -10,7 +10,8 @@ import BlogRelatedPosts from "@/components/blog/BlogRelatedPosts";
 import { ArrowLeft, Clock, Calendar } from "lucide-react";
 import type { BlogPost } from "@/types/views";
 
-export const dynamic = 'force-dynamic'
+export const revalidate = 3600;
+export const dynamicParams = true;
 
 const FALLBACK_IMAGE =
   "https://images.unsplash.com/photo-1416879595882-3373a0480b5b?w=800&q=80";
@@ -32,6 +33,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title: post.title,
     description: post.excerpt,
+    alternates: { canonical: `/blog/${slug}` },
   };
 }
 

--- a/src/app/(site)/blog/page.tsx
+++ b/src/app/(site)/blog/page.tsx
@@ -5,7 +5,7 @@ import BlogListClient from "@/components/blog/BlogListClient";
 import type { BlogPost } from "@/types/views";
 import { getImageUrl } from "@/lib/utils";
 
-export const dynamic = 'force-dynamic'
+export const revalidate = 3600;
 
 const FALLBACK_IMAGE =
   "https://images.unsplash.com/photo-1416879595882-3373a0480b5b?w=800&q=80";
@@ -13,6 +13,7 @@ const FALLBACK_IMAGE =
 export const metadata: Metadata = {
   title: "Blog",
   description: "Korisni savjeti i novosti iz svijeta poljoprivrede - proljetna gnojidba, zastita bilja, navodnjavanje i jos mnogo toga.",
+  alternates: { canonical: "/blog" },
 };
 
 export default async function BlogPage() {

--- a/src/app/(site)/kontakt/page.tsx
+++ b/src/app/(site)/kontakt/page.tsx
@@ -6,6 +6,7 @@ import LegalData from "@/components/contact/LegalData";
 export const metadata: Metadata = {
   title: "Kontakt",
   description: "Kontaktirajte Oroz PHARM d.o.o. - Pleternica i Pozega. Telefon, email, adrese i radno vrijeme nasih poslovnica.",
+  alternates: { canonical: "/kontakt" },
 };
 
 export default function ContactPage() {

--- a/src/app/(site)/layout.tsx
+++ b/src/app/(site)/layout.tsx
@@ -18,6 +18,7 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://www.orozpharm.hr"),
   title: {
     default: "Oroz PHARM | Poljoprivredna ljekarna",
     template: "%s | Oroz PHARM",

--- a/src/app/(site)/o-nama/page.tsx
+++ b/src/app/(site)/o-nama/page.tsx
@@ -9,6 +9,7 @@ import { Users, Package, TrendingUp, MapPin } from "lucide-react";
 export const metadata: Metadata = {
   title: "O nama",
   description: "Oroz PHARM d.o.o. - privatno poduzece osnovano 1998. godine u Pleternici. 10+ zaposlenih, preko 15.000 artikala.",
+  alternates: { canonical: "/o-nama" },
 };
 
 const stats = [

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { getPayload } from "payload";
 import config from "@payload-config";
 import HeroSlideshow from "@/components/home/HeroSlideshow";
@@ -9,7 +10,11 @@ import LeafDivider from "@/components/shared/LeafDivider";
 import type { BlogPost } from "@/types/views";
 import { getImageUrl } from "@/lib/utils";
 
-export const dynamic = 'force-dynamic'
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/" },
+};
 
 const FALLBACK_IMAGE =
   "https://images.unsplash.com/photo-1416879595882-3373a0480b5b?w=800&q=80";

--- a/src/app/(site)/proizvodi/[category]/[product]/page.tsx
+++ b/src/app/(site)/proizvodi/[category]/[product]/page.tsx
@@ -23,7 +23,7 @@ export const revalidate = 60;
 export const dynamicParams = true;
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { product: slug } = await params;
+  const { category, product: slug } = await params;
   const payload = await getPayload({ config });
   const { docs } = await payload.find({
     collection: "products",
@@ -35,6 +35,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title: doc.name,
     description: doc.description ?? undefined,
+    alternates: { canonical: `/proizvodi/${category}/${slug}` },
   };
 }
 

--- a/src/app/(site)/proizvodi/[category]/page.tsx
+++ b/src/app/(site)/proizvodi/[category]/page.tsx
@@ -52,6 +52,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title: cat.name,
     description: cat.description ?? undefined,
+    alternates: { canonical: `/proizvodi/${slug}` },
   };
 }
 

--- a/src/app/(site)/proizvodi/page.tsx
+++ b/src/app/(site)/proizvodi/page.tsx
@@ -10,11 +10,12 @@ import { getImageUrl } from "@/lib/utils";
 const FALLBACK_IMAGE =
   "https://images.unsplash.com/photo-1500382017468-9049fed747ef?w=800&q=80";
 
-export const dynamic = 'force-dynamic'
+export const revalidate = 3600;
 
 export const metadata: Metadata = {
   title: "Proizvodi",
   description: "Pregledajte naš asortiman od preko 15.000 artikala - zaštita bilja, gnojiva, sjeme, navodnjavanje, stočna hrana i još mnogo toga.",
+  alternates: { canonical: "/proizvodi" },
 };
 
 export default async function ProductsPage() {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -5,7 +5,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: "*",
       allow: "/",
-      disallow: ["/admin/", "/api/"],
+      disallow: ["/admin/", "/api/", "/proizvodi/dokumenti/"],
     },
     sitemap: "https://www.orozpharm.hr/sitemap.xml",
   };

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -7,9 +7,10 @@ const BASE_URL = "https://www.orozpharm.hr";
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const payload = await getPayload({ config });
 
-  const [{ docs: categories }, { docs: blogs }] = await Promise.all([
+  const [{ docs: categories }, { docs: blogs }, { docs: products }] = await Promise.all([
     payload.find({ collection: "categories", limit: 200, depth: 0 }),
     payload.find({ collection: "blogs", limit: 200, depth: 0 }),
+    payload.find({ collection: "products", limit: 2000, depth: 1 }),
   ]);
 
   const staticRoutes: MetadataRoute.Sitemap = [
@@ -34,5 +35,19 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.6,
   }));
 
-  return [...staticRoutes, ...categoryRoutes, ...blogRoutes];
+  const productRoutes: MetadataRoute.Sitemap = products.flatMap((product) => {
+    const categorySlug =
+      typeof product.category === "object" && product.category !== null
+        ? product.category.slug
+        : null;
+    if (!categorySlug) return [];
+    return [{
+      url: `${BASE_URL}/proizvodi/${categorySlug}/${product.slug}`,
+      lastModified: new Date(product.updatedAt),
+      changeFrequency: "monthly" as const,
+      priority: 0.7,
+    }];
+  });
+
+  return [...staticRoutes, ...categoryRoutes, ...blogRoutes, ...productRoutes];
 }


### PR DESCRIPTION
- Dodaj metadataBase u site layout za ispravno razrješavanje URL-ova
- Dodaj alternates.canonical na sve stranice (home, blog, proizvodi, o-nama, kontakt, dinamičke rute)
- Ukloni force-dynamic s home/blog/proizvodi stranica, zamijeni s revalidate = 3600
- Blokiraj /proizvodi/dokumenti/ u robots.txt (stari PDF-ovi s prethodnog weba)
- Dodaj individualne produkte u sitemap.ts