### PR TITLE
feat: pretraživanje proizvoda (pg_trgm global search)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "seed:related": "node --env-file=.env.local src/scripts/seed-related-categories.js",
     "seed:tora": "node --env-file=.env.local src/scripts/seed-tora-products.js",
     "seed:f1": "node --env-file=.env.local src/scripts/seed-f1-hibridi.js",
-    "migrate:r2": "node --env-file=.env.local src/scripts/migrate-to-r2.js"
+    "migrate:r2": "node --env-file=.env.local src/scripts/migrate-to-r2.js",
+    "migrate:search-indexes": "node --env-file=.env.local src/scripts/add-search-indexes.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/src/app/(site)/proizvodi/pretraga/page.tsx
+++ b/src/app/(site)/proizvodi/pretraga/page.tsx
@@ -31,7 +31,7 @@ export default async function SearchPage({ searchParams }: Props) {
   const totalPages = Math.ceil(total / PAGE_SIZE);
 
   return (
-    <div className="max-w-7xl mx-auto px-4 md:px-8 pt-28 md:pt-36 pb-16 min-h-[60vh]">
+    <div className="max-w-7xl mx-auto px-4 md:px-8 pt-8 md:pt-12 pb-16 min-h-[60vh]">
       <Link
         href="/proizvodi"
         className="inline-flex items-center gap-1 text-green-700 text-sm mb-6 hover:text-green-900 transition-colors"

--- a/src/app/(site)/proizvodi/pretraga/page.tsx
+++ b/src/app/(site)/proizvodi/pretraga/page.tsx
@@ -1,0 +1,97 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import ProductCard from "@/components/products/ProductCard";
+import { searchProducts } from "@/lib/search";
+
+export const dynamic = "force-dynamic";
+
+const PAGE_SIZE = 24;
+
+export const metadata: Metadata = {
+  title: "Pretraga proizvoda",
+  robots: { index: false, follow: true },
+};
+
+interface Props {
+  searchParams: Promise<{ q?: string; page?: string }>;
+}
+
+export default async function SearchPage({ searchParams }: Props) {
+  const { q = "", page = "1" } = await searchParams;
+  const query = q.trim();
+  const currentPage = Math.max(1, parseInt(page, 10) || 1);
+  const offset = (currentPage - 1) * PAGE_SIZE;
+
+  const { products, total } =
+    query.length >= 2
+      ? await searchProducts(query, { limit: PAGE_SIZE, offset })
+      : { products: [], total: 0 };
+
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 md:px-8 pt-28 md:pt-36 pb-16 min-h-[60vh]">
+      <Link
+        href="/proizvodi"
+        className="inline-flex items-center gap-1 text-green-700 text-sm mb-6 hover:text-green-900 transition-colors"
+      >
+        <ArrowLeft size={16} /> Svi proizvodi
+      </Link>
+
+      <h1 className="text-3xl md:text-4xl font-bold text-green-900 font-heading mb-2">
+        Rezultati pretrage
+      </h1>
+      {query.length >= 2 ? (
+        <p className="text-gray-500 mb-10">
+          {total} {total === 1 ? "rezultat" : "rezultata"} za "{query}"
+        </p>
+      ) : (
+        <p className="text-gray-500 mb-10">
+          Upišite pojam za pretragu (najmanje 2 znaka).
+        </p>
+      )}
+
+      {products.length > 0 ? (
+        <>
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-5">
+            {products.map((p, i) => (
+              <ProductCard key={p.id} product={p} priority={i < 8} />
+            ))}
+          </div>
+
+          {totalPages > 1 && (
+            <div className="flex flex-wrap items-center justify-center gap-2 mt-12">
+              {Array.from({ length: totalPages }, (_, i) => i + 1).map((n) => (
+                <Link
+                  key={n}
+                  href={`/proizvodi/pretraga?q=${encodeURIComponent(query)}&page=${n}`}
+                  className={`w-9 h-9 flex items-center justify-center rounded-lg text-sm font-medium transition-colors ${
+                    n === currentPage
+                      ? "bg-green-700 text-white"
+                      : "border border-green-200 text-green-800 hover:bg-green-50"
+                  }`}
+                >
+                  {n}
+                </Link>
+              ))}
+            </div>
+          )}
+        </>
+      ) : query.length >= 2 ? (
+        <div className="py-16 text-center">
+          <p className="text-gray-500 text-lg">Nema rezultata za "{query}".</p>
+          <p className="text-gray-400 text-sm mt-2">
+            Provjerite pravopis ili nas kontaktirajte za pomoć pri pronalasku proizvoda.
+          </p>
+          <Link
+            href="/kontakt"
+            className="inline-block mt-6 text-green-700 font-medium text-sm hover:underline"
+          >
+            Kontaktirajte nas →
+          </Link>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { searchProducts } from "@/lib/search";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const q = searchParams.get("q") ?? "";
+  try {
+    const { products } = await searchProducts(q, { limit: 8 });
+    return NextResponse.json({ products });
+  } catch (err) {
+    console.error("[/api/search]", err);
+    return NextResponse.json({ products: [] }, { status: 500 });
+  }
+}

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -7,7 +7,7 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const q = searchParams.get("q") ?? "";
   try {
-    const { products } = await searchProducts(q, { limit: 8 });
+    const { products } = await searchProducts(q, { limit: 8, countTotal: false });
     return NextResponse.json({ products });
   } catch (err) {
     console.error("[/api/search]", err);

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -7,19 +7,22 @@ import { useState, useCallback } from "react";
 import { navLinks } from "@/data/navigation";
 import { cn } from "@/lib/utils";
 import MobileNav from "./MobileNav";
-import { Menu } from "lucide-react";
+import SearchBar from "@/components/products/SearchBar";
+import { Menu, Search, X } from "lucide-react";
 
 export default function Header() {
   const pathname = usePathname();
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
 
   const closeMobile = useCallback(() => setMobileOpen(false), []);
+  const closeSearch = useCallback(() => setSearchOpen(false), []);
 
   return (
     <>
       <header className="fixed top-0 left-0 right-0 z-50 bg-white shadow-md py-3 md:py-5">
-        <div className="max-w-7xl mx-auto px-4 md:px-8 flex items-center justify-between">
-          <Link href="/" className="flex items-center gap-2 md:gap-3">
+        <div className="max-w-7xl mx-auto px-4 md:px-8 flex items-center justify-between gap-4">
+          <Link href="/" className="flex items-center gap-2 md:gap-3 shrink-0">
             <Image
               src="/images/logo-oroz.png"
               alt="Oroz PHARM - Poljoprivredne ljekarne"
@@ -58,16 +61,48 @@ export default function Header() {
             })}
           </nav>
 
-          {/* Mobile hamburger */}
-          <button
-            onClick={() => setMobileOpen(true)}
-            className="lg:hidden p-2 rounded-lg transition-colors text-green-900 hover:bg-green-50"
-            aria-label="Otvori izbornik"
-          >
-            <Menu size={24} />
-          </button>
+          {/* Desktop search */}
+          <div className="hidden lg:block w-64 xl:w-72">
+            <SearchBar />
+          </div>
+
+          {/* Mobile actions */}
+          <div className="flex items-center gap-1 lg:hidden">
+            <button
+              onClick={() => setSearchOpen(true)}
+              className="p-2 rounded-lg transition-colors text-green-900 hover:bg-green-50"
+              aria-label="Pretraži proizvode"
+            >
+              <Search size={24} />
+            </button>
+            <button
+              onClick={() => setMobileOpen(true)}
+              className="p-2 rounded-lg transition-colors text-green-900 hover:bg-green-50"
+              aria-label="Otvori izbornik"
+            >
+              <Menu size={24} />
+            </button>
+          </div>
         </div>
       </header>
+
+      {/* Mobile search overlay */}
+      {searchOpen && (
+        <div className="fixed inset-0 z-70 bg-white lg:hidden">
+          <div className="flex items-center gap-2 px-4 py-4 border-b border-green-100">
+            <div className="flex-1">
+              <SearchBar autoFocus onNavigate={closeSearch} />
+            </div>
+            <button
+              onClick={closeSearch}
+              className="p-2 rounded-lg text-green-900 hover:bg-green-50"
+              aria-label="Zatvori pretragu"
+            >
+              <X size={24} />
+            </button>
+          </div>
+        </div>
+      )}
 
       <MobileNav open={mobileOpen} onClose={closeMobile} />
     </>

--- a/src/components/products/SearchBar.tsx
+++ b/src/components/products/SearchBar.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import { Search, Loader2 } from "lucide-react";
+import type { Product } from "@/types/views";
+
+interface Props {
+  autoFocus?: boolean;
+  onNavigate?: () => void;
+  placeholder?: string;
+}
+
+export default function SearchBar({
+  autoFocus = false,
+  onNavigate,
+  placeholder = "Pretraži proizvode...",
+}: Props) {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState(-1);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Debounced dohvat
+  useEffect(() => {
+    const q = query.trim();
+    if (q.length < 2) {
+      setResults([]);
+      setOpen(false);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const t = setTimeout(async () => {
+      abortRef.current?.abort();
+      const ctrl = new AbortController();
+      abortRef.current = ctrl;
+      try {
+        const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`, {
+          signal: ctrl.signal,
+        });
+        const data = await res.json();
+        setResults(data.products ?? []);
+        setOpen(true);
+        setHighlight(-1);
+      } catch (e) {
+        if ((e as Error).name !== "AbortError") setResults([]);
+      } finally {
+        setLoading(false);
+      }
+    }, 200);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  // Zatvori na klik izvan
+  useEffect(() => {
+    function onClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, []);
+
+  const goToResults = useCallback(() => {
+    const q = query.trim();
+    if (q.length < 2) return;
+    setOpen(false);
+    onNavigate?.();
+    router.push(`/proizvodi/pretraga?q=${encodeURIComponent(q)}`);
+  }, [query, router, onNavigate]);
+
+  const goToProduct = useCallback(
+    (p: Product) => {
+      setOpen(false);
+      onNavigate?.();
+      router.push(`/proizvodi/${p.categorySlug}/${p.slug}`);
+    },
+    [router, onNavigate]
+  );
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlight((h) => Math.min(h + 1, results.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlight((h) => Math.max(h - 1, -1));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (highlight >= 0 && results[highlight]) goToProduct(results[highlight]);
+      else goToResults();
+    } else if (e.key === "Escape") {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div ref={containerRef} className="relative w-full">
+      <div className="relative">
+        <Search
+          size={18}
+          className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none"
+        />
+        <input
+          type="text"
+          value={query}
+          autoFocus={autoFocus}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={onKeyDown}
+          onFocus={() => {
+            if (results.length > 0) setOpen(true);
+          }}
+          placeholder={placeholder}
+          aria-label="Pretraži proizvode"
+          className="w-full rounded-full border border-green-200 bg-white py-2 pl-10 pr-10 text-sm text-green-900 placeholder:text-gray-400 focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500/20"
+        />
+        {loading && (
+          <Loader2
+            size={18}
+            className="absolute right-3 top-1/2 -translate-y-1/2 animate-spin text-green-500"
+          />
+        )}
+      </div>
+
+      {open && (results.length > 0 || !loading) && (
+        <div className="absolute left-0 right-0 top-full z-50 mt-2 overflow-hidden rounded-xl border border-green-100 bg-white shadow-xl">
+          {results.length > 0 ? (
+            <>
+              <ul>
+                {results.map((p, i) => (
+                  <li key={p.id}>
+                    <button
+                      type="button"
+                      onMouseEnter={() => setHighlight(i)}
+                      onClick={() => goToProduct(p)}
+                      className={`flex w-full items-center gap-3 px-3 py-2 text-left transition-colors ${
+                        i === highlight ? "bg-green-50" : "hover:bg-green-50"
+                      }`}
+                    >
+                      <span className="relative h-10 w-10 shrink-0 overflow-hidden rounded bg-white">
+                        <Image
+                          src={p.image}
+                          alt={p.name}
+                          fill
+                          sizes="40px"
+                          className="object-contain mix-blend-multiply"
+                        />
+                      </span>
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-sm font-medium text-green-900">
+                          {p.name}
+                        </span>
+                        {p.manufacturer && (
+                          <span className="block truncate text-xs text-green-700">
+                            {p.manufacturer}
+                          </span>
+                        )}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              <button
+                type="button"
+                onClick={goToResults}
+                className="block w-full border-t border-green-100 bg-green-50 px-3 py-2.5 text-center text-sm font-semibold text-green-800 hover:bg-green-100"
+              >
+                Prikaži sve rezultate za "{query.trim()}"
+              </button>
+            </>
+          ) : (
+            <div className="px-3 py-4 text-center text-sm text-gray-500">
+              Nema rezultata za "{query.trim()}".
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/products/SearchBar.tsx
+++ b/src/components/products/SearchBar.tsx
@@ -49,7 +49,10 @@ export default function SearchBar({
         setOpen(true);
         setHighlight(-1);
       } catch (e) {
-        if ((e as Error).name !== "AbortError") setResults([]);
+        if ((e as Error).name !== "AbortError") {
+          setResults([]);
+          setOpen(false);
+        }
       } finally {
         setLoading(false);
       }

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -20,6 +20,7 @@ const MATCH_SQL = `
   WHERE p.name ILIKE '%' || $1 || '%'
      OR m.name ILIKE '%' || $1 || '%'
      OR similarity(p.name, $1) > $2
+     OR similarity(m.name, $1) > $2
   ORDER BY GREATEST(similarity(p.name, $1), COALESCE(similarity(m.name, $1), 0)) DESC, p.name ASC
   LIMIT $3 OFFSET $4
 `;
@@ -31,6 +32,7 @@ const COUNT_SQL = `
   WHERE p.name ILIKE '%' || $1 || '%'
      OR m.name ILIKE '%' || $1 || '%'
      OR similarity(p.name, $1) > $2
+     OR similarity(m.name, $1) > $2
 `;
 
 export async function searchProducts(

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -37,7 +37,7 @@ const COUNT_SQL = `
 
 export async function searchProducts(
   rawQuery: string,
-  { limit = 8, offset = 0 }: { limit?: number; offset?: number } = {}
+  { limit = 8, offset = 0, countTotal = true }: { limit?: number; offset?: number; countTotal?: boolean } = {}
 ): Promise<SearchResult> {
   const q = rawQuery.trim();
   if (q.length < 2) return { products: [], total: 0 };
@@ -45,13 +45,18 @@ export async function searchProducts(
   const payload = await getPayload({ config });
   const pool = (payload.db as unknown as { pool: Pool }).pool;
 
-  const [matchRes, countRes] = await Promise.all([
-    pool.query<{ id: number }>(MATCH_SQL, [q, SIMILARITY_THRESHOLD, limit, offset]),
-    pool.query<{ total: number }>(COUNT_SQL, [q, SIMILARITY_THRESHOLD]),
-  ]);
+  // WHERE uses bare similarity() (NULL is falsy, so unmatched manufacturers are excluded correctly);
+  // ORDER BY coalesces NULL to 0 so unmatched manufacturers sort last rather than erroring.
+  const matchRes = await pool.query<{ id: number }>(MATCH_SQL, [q, SIMILARITY_THRESHOLD, limit, offset]);
+
+  let total = 0;
+  if (countTotal) {
+    const countRes = await pool.query<{ total: number }>(COUNT_SQL, [q, SIMILARITY_THRESHOLD]);
+    total = countRes.rows[0]?.total ?? 0;
+  }
 
   const ids = matchRes.rows.map((r) => r.id);
-  const total = countRes.rows[0]?.total ?? 0;
+  if (!countTotal) total = ids.length;
   if (ids.length === 0) return { products: [], total };
 
   // Hidracija kroz Payload radi reuse-a media/URL logike (R2) i relacija.

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,0 +1,90 @@
+import { getPayload } from "payload";
+import config from "@payload-config";
+import type { Pool } from "pg";
+import type { Product } from "@/types/views";
+import { getImageUrl } from "@/lib/utils";
+
+const FALLBACK_IMAGE =
+  "https://images.unsplash.com/photo-1500382017468-9049fed747ef?w=400&q=80";
+const SIMILARITY_THRESHOLD = 0.3;
+
+export interface SearchResult {
+  products: Product[];
+  total: number;
+}
+
+const MATCH_SQL = `
+  SELECT p.id AS id
+  FROM products p
+  LEFT JOIN manufacturers m ON p.manufacturer_id = m.id
+  WHERE p.name ILIKE '%' || $1 || '%'
+     OR m.name ILIKE '%' || $1 || '%'
+     OR similarity(p.name, $1) > $2
+  ORDER BY GREATEST(similarity(p.name, $1), COALESCE(similarity(m.name, $1), 0)) DESC, p.name ASC
+  LIMIT $3 OFFSET $4
+`;
+
+const COUNT_SQL = `
+  SELECT COUNT(*)::int AS total
+  FROM products p
+  LEFT JOIN manufacturers m ON p.manufacturer_id = m.id
+  WHERE p.name ILIKE '%' || $1 || '%'
+     OR m.name ILIKE '%' || $1 || '%'
+     OR similarity(p.name, $1) > $2
+`;
+
+export async function searchProducts(
+  rawQuery: string,
+  { limit = 8, offset = 0 }: { limit?: number; offset?: number } = {}
+): Promise<SearchResult> {
+  const q = rawQuery.trim();
+  if (q.length < 2) return { products: [], total: 0 };
+
+  const payload = await getPayload({ config });
+  const pool = (payload.db as unknown as { pool: Pool }).pool;
+
+  const [matchRes, countRes] = await Promise.all([
+    pool.query<{ id: number }>(MATCH_SQL, [q, SIMILARITY_THRESHOLD, limit, offset]),
+    pool.query<{ total: number }>(COUNT_SQL, [q, SIMILARITY_THRESHOLD]),
+  ]);
+
+  const ids = matchRes.rows.map((r) => r.id);
+  const total = countRes.rows[0]?.total ?? 0;
+  if (ids.length === 0) return { products: [], total };
+
+  // Hidracija kroz Payload radi reuse-a media/URL logike (R2) i relacija.
+  const { docs } = await payload.find({
+    collection: "products",
+    where: { id: { in: ids } },
+    depth: 1,
+    limit: ids.length,
+  });
+
+  // Sačuvaj SQL poredak (relevantnost).
+  const byId = new Map(docs.map((d) => [Number(d.id), d]));
+  const products: Product[] = ids
+    .map((id) => byId.get(id))
+    .filter((d): d is NonNullable<typeof d> => Boolean(d))
+    .map((doc) => ({
+      id: String(doc.id),
+      slug: doc.slug,
+      categorySlug:
+        typeof doc.category === "object" && doc.category !== null
+          ? doc.category.slug
+          : "",
+      subcategoryId:
+        typeof doc.subcategory === "object" && doc.subcategory !== null
+          ? String(doc.subcategory.id)
+          : String(doc.subcategory ?? ""),
+      name: doc.name,
+      manufacturer:
+        typeof doc.manufacturer === "object" && doc.manufacturer !== null
+          ? doc.manufacturer.name
+          : "",
+      description: doc.description ?? "",
+      instructions: doc.instructions,
+      image: getImageUrl(doc.image, FALLBACK_IMAGE),
+    }));
+
+  return { products, total };
+}

--- a/src/scripts/add-search-indexes.js
+++ b/src/scripts/add-search-indexes.js
@@ -1,0 +1,23 @@
+import { Pool } from "pg";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URI });
+
+const statements = [
+  `CREATE EXTENSION IF NOT EXISTS pg_trgm;`,
+  `CREATE INDEX IF NOT EXISTS idx_products_name_trgm ON products USING gin (name gin_trgm_ops);`,
+  `CREATE INDEX IF NOT EXISTS idx_manufacturers_name_trgm ON manufacturers USING gin (name gin_trgm_ops);`,
+];
+
+async function main() {
+  for (const sql of statements) {
+    await pool.query(sql);
+    console.log("✓", sql.split("\n")[0]);
+  }
+  await pool.end();
+  console.log("Gotovo.");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Pretraživanje proizvoda

Globalna pretraga proizvoda dostupna iz headera na svakoj stranici, pokretana PostgreSQL `pg_trgm` trigram pretragom (typo-tolerantna), s autocomplete dropdownom i dediciranom results stranicom.

### Što je dodano
- **pg_trgm migracija** — ekstenzija + GIN trigram indeksi (`src/scripts/add-search-indexes.js`, `npm run migrate:search-indexes`)
- **`searchProducts()`** core — parametrizirani SQL preko Payload pg poola, pretraga po **nazivu + proizvođaču**, hidracija kroz Payload (reuse media/URL logike), čuva relevantni poredak; COUNT se preskače na autocomplete putanji
- **`/api/search`** — autocomplete endpoint (top 8)
- **`SearchBar`** — client komponenta (debounce 200ms, keyboard nav, error handling)
- **Header** — desktop inline search + mobilni fullscreen overlay
- **`/proizvodi/pretraga`** — results stranica (paginacija, empty state, `noindex`)

### Proces
Dizajn (spec) → plan → subagent-driven implementacija (6 taskova), per-task review + završni whole-branch review. Sve provjereno s `next build` (nema test runnera).

### ⚠️ Deploy — obavezna jednokratna prod migracija
Prije/uz deploy pokrenuti na prod bazi **kao postgres superuser** (NE `npm run migrate:search-indexes` — `orozpharm_user` nema prava):
\`\`\`bash
sudo -u postgres psql -d orozpharm -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
sudo -u postgres psql -d orozpharm -c "CREATE INDEX IF NOT EXISTS idx_products_name_trgm ON products USING gin (name gin_trgm_ops);"
sudo -u postgres psql -d orozpharm -c "CREATE INDEX IF NOT EXISTS idx_manufacturers_name_trgm ON manufacturers USING gin (name gin_trgm_ops);"
\`\`\`

### Napomena o redoslijedu (stacked PR)
Ovaj PR cilja na `feat/showcase-subcategories`. Nakon merge-a PR #38 (showcase → main), prebaci bazu ovog PR-a na `main` (GitHub "Edit" → base: main) pa mergeaj — tada prikazuje samo search commitove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)